### PR TITLE
Change M68K opcode table URL

### DIFF
--- a/disasm/README.md
+++ b/disasm/README.md
@@ -6,3 +6,10 @@ or other formats, you will need to convert the file to binary.
 
 Thanks to GoldenCrystal for the helpful table of 68000 opcodes at
 http://goldencrystal.free.fr/M68kOpcodes-v2.4.pdf
+
+-----
+Link to that nicely organised 68000 opcode table has changed. Try this:
+* http://goldencrystal.free.fr/M68kOpcodes
+
+Otherwise, use the presumably-previous version:
+* http://goldencrystal.free.fr/M68kOpcodes-v2.3.pdf


### PR DESCRIPTION
The link to that nicely organised 68000 opcode table no longer works.

Two working alternatives are suggested.