### PR TITLE
Python refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+# Ignore source and compiled vasm
+/disasm/vasm.tar.gz
+/disasm/vasm/

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+pycodestyle = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,29 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e662b66f565ab87e5e39b49a12cbfc783a90ae21997bc88b5f0390ae5a65cff7"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        }
+    }
+}

--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -1,16 +1,19 @@
-%.bin : %.s
-	$(AS) $(ASFLAGS) -L $*.lst -o $@ $<
-
-AS	= vasmm68k_mot
+AS = vasmm68k_mot
 ASFLAGS = -quiet -m68000 -no-opt -Fbin
 
-all:	testprog.bin pep8
+%.bin: %.s
+	$(AS) $(ASFLAGS) -L $*.lst -o $@ $<
+
+all: testprog.bin pep8
+
+install:
+	pip3 install --user pipenv; ~/.local/bin/pipenv --three install --dev
 
 pep8:
-	pycodestyle --max-line-length=256 disasm68k.py
+	~/.local/bin/pipenv run pycodestyle --max-line-length=121 disasm68k.py
 
 output.s: testprog.bin
-	./disasm68k.py -n testprog.bin >output.s
+	~/.local/bin/pipenv run python disasm68k.py -n testprog.bin >output.s
 
 compare: output.bin output.s
 	hexdump -C testprog.bin >testprog.hex

--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -8,7 +8,8 @@ all: testprog.bin pep8
 
 install:
 	echo "Installing Python dependencies"
-	pip3 install --user pipenv; ~/.local/bin/pipenv --three install --dev
+	pip3 install --user pipenv
+	~/.local/bin/pipenv --three install --dev
 	echo "Installing VASM dependencies"
 	wget http://sun.hasenbraten.de/vasm/release/vasm.tar.gz
 	tar xvzf vasm.tar.gz

--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -1,4 +1,4 @@
-AS = vasmm68k_mot
+AS = vasm/vasmm68k_mot
 ASFLAGS = -quiet -m68000 -no-opt -Fbin
 
 %.bin: %.s
@@ -7,10 +7,21 @@ ASFLAGS = -quiet -m68000 -no-opt -Fbin
 all: testprog.bin pep8
 
 install:
+	echo "Installing Python dependencies"
 	pip3 install --user pipenv; ~/.local/bin/pipenv --three install --dev
+	echo "Installing VASM dependencies"
+	curl --fail --location --silent http://sun.hasenbraten.de/vasm/release/vasm.tar.gz -O vasm.tar.gz
+	tar xvzf vasm.tar.gz
+	cd vasm && make CPU=m68k SYNTAX=mot && cd ..
 
 pep8:
 	~/.local/bin/pipenv run pycodestyle --max-line-length=121 disasm68k.py
+
+test: vasm/vasmm68k_mot testprog.s disasm68k.py
+	echo "Compiling S-record to binary"
+	$(AS) $(ASFLAGS) -L $*.lst -o testprog.bin testprog.s
+	echo "Disassembling binary back to S-record"
+	~/.local/bin/pipenv run python disasm68k.py -n testprog.bin >output.s
 
 output.s: testprog.bin
 	~/.local/bin/pipenv run python disasm68k.py -n testprog.bin >output.s

--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -10,9 +10,10 @@ install:
 	echo "Installing Python dependencies"
 	pip3 install --user pipenv; ~/.local/bin/pipenv --three install --dev
 	echo "Installing VASM dependencies"
-	curl --fail --location --silent http://sun.hasenbraten.de/vasm/release/vasm.tar.gz -O vasm.tar.gz
+	wget http://sun.hasenbraten.de/vasm/release/vasm.tar.gz
 	tar xvzf vasm.tar.gz
 	cd vasm && make CPU=m68k SYNTAX=mot && cd ..
+	echo "All dependencies successfully installed"
 
 pep8:
 	~/.local/bin/pipenv run pycodestyle --max-line-length=121 disasm68k.py

--- a/disasm/README.md
+++ b/disasm/README.md
@@ -1,8 +1,22 @@
-This is a disassembler for the Motorola 68000 microprocessor, written
-in Python.
+# 68000 Disassembler
+This is a disassembler for the Motorola 68000 microprocessor, written in Python. The input data must be in binary 
+format. If you want to read S record or other formats, you will need to convert the file to binary.
 
-The input data must be in binary format. If you want to read S record
-or other formats, you will need to convert the file to binary.
+Thanks to GoldenCrystal for the helpful table of 68000 opcodes at http://goldencrystal.free.fr/M68kOpcodes-v2.3.pdf
 
-Thanks to GoldenCrystal for the helpful table of 68000 opcodes at
-http://goldencrystal.free.fr/M68kOpcodes-v2.3.pdf
+## Usage
+Install the dependencies using
+```bash
+make install
+```
+
+Now, you can disassemble a binary file, for example the sample file in this directory using
+```bash
+make testprog.bin  # This will create testprog.s
+```
+
+### Testing
+Test the toolchain using
+```bash
+make test
+```


### PR DESCRIPTION
Hi Jeff,

Since I happen to be a Python developer on weekdays, I tried my hand at refactoring some stuff in the disasm folder. I never worked with Make much so it was a bit of a fiddle (and I haven't touched any of the Python stuff yet) but I learned a lot. Make is pretty great.

Some things I changed:
- Use [pipenv](https://pipenv.pypa.io/en/latest/) to manage the virtual environment (which is always a good idea), dependencies (such as pycodestyle) and automatically use the correct Python version. The Pipfile and Pipfile.lock files in the project root are detected automatically by pipenv and list the Python requirements.
- Add an "install" make target to download and compile vasm to a local folder
- Add a "test" target to test the basic functionality of the complete toolchain
- Add a couple of usage instructions in the README in the disasm folder

The complete setup was written and tested working on a Raspberry Pi